### PR TITLE
big5 as []byte

### DIFF
--- a/big5.go
+++ b/big5.go
@@ -5,14 +5,14 @@ import (
 	"golang.org/x/text/transform"
 )
 
-func Utf8ToBig5(input string) string {
+func Utf8ToBig5(input string) []byte {
 	utf8ToBig5 := traditionalchinese.Big5.NewEncoder()
-	big5, _, _ := transform.String(utf8ToBig5, input)
+	big5, _, _ := transform.Bytes(utf8ToBig5, []byte(input))
 	return big5
 }
 
-func Big5ToUtf8(input string) string {
+func Big5ToUtf8(input []byte) string {
 	big5ToUTF8 := traditionalchinese.Big5.NewDecoder()
-	utf8, _, _ := transform.String(big5ToUTF8, input)
+	utf8, _, _ := transform.String(big5ToUTF8, string(input))
 	return utf8
 }

--- a/big5_test.go
+++ b/big5_test.go
@@ -1,0 +1,56 @@
+package bbs
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestUtf8ToBig5(t *testing.T) {
+	type args struct {
+		input string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []byte
+	}{
+		// TODO: Add test cases.
+		{
+			name: "test0",
+			args: args{input: "新的目錄"},
+			want: []byte{183, 115, 170, 186, 165, 216, 191, 253},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Utf8ToBig5(tt.args.input); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Utf8ToBig5() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBig5ToUtf8(t *testing.T) {
+	type args struct {
+		input []byte
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		// TODO: Add test cases.
+		{
+			name: "test0",
+			args: args{input: []byte{183, 115, 170, 186, 165, 216, 191, 253}},
+			want: "新的目錄",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Big5ToUtf8(tt.args.input); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Big5ToUtf8() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/file.go
+++ b/file.go
@@ -11,6 +11,7 @@ package bbs
 import (
 	"bytes"
 	"encoding/binary"
+
 	// "iconv"
 	"io"
 	"log"
@@ -119,7 +120,7 @@ func NewFileHeaderWithByte(data []byte) (*FileHeader, error) {
 	ret.Recommend = int8(data[PosOfPTTRecommend])
 	ret.Owner = string(bytes.Trim(data[PosOfPTTOwner:PosOfPTTOwner+PTT_IDLEN+2], "\x00"))
 	ret.Date = string(bytes.Trim(data[PosOfPTTDate:PosOfPTTDate+6], "\x00"))
-	ret.Title = Big5ToUtf8(string(bytes.Trim(data[PosOfPTTTitle:PosOfPTTTitle+PTT_TTLEN+1], "\x00")))
+	ret.Title = Big5ToUtf8(bytes.Trim(data[PosOfPTTTitle:PosOfPTTTitle+PTT_TTLEN+1], "\x00"))
 	// log.Println("PosOfUnionMulti:", PosOfUnionMulti, data[PosOfUnionMulti])
 
 	ret.Money = int(binary.LittleEndian.Uint32(data[PosOfPTTUnionMulti : PosOfPTTUnionMulti+4]))

--- a/file_formosabbs.go
+++ b/file_formosabbs.go
@@ -61,7 +61,7 @@ func NewFomosaBBSFileHeaderWithByte(data []byte) (*FileHeader, error) {
 	// ret.Recommend = int8(data[PosOfRecommend])
 	ret.Owner = string(bytes.Trim(data[PosOfFormosaBBSOwner:PosOfFormosaBBSOwner+72], "\x00"))
 	// ret.Date = string(bytes.Trim(data[PosOfDate:PosOfDate+6], "\x00"))
-	ret.Title = Big5ToUtf8(string(bytes.Trim(data[PosOfFormosaBBSTitle:PosOfFormosaBBSTitle+67], "\x00")))
+	ret.Title = Big5ToUtf8(bytes.Trim(data[PosOfFormosaBBSTitle:PosOfFormosaBBSTitle+67], "\x00"))
 	// // log.Println("PosOfUnionMulti:", PosOfUnionMulti, data[PosOfUnionMulti])
 
 	// ret.Money = int(binary.LittleEndian.Uint32(data[PosOfUnionMulti : PosOfUnionMulti+4]))


### PR DESCRIPTION
This is to avoid the tedious confusion / conflict of the naming / type issue in the future.

Suggestion: have data-big5 as []byte